### PR TITLE
fix: If date is null, it shows TBD

### DIFF
--- a/src/components/Main/Hero.astro
+++ b/src/components/Main/Hero.astro
@@ -12,11 +12,15 @@ interface Props {
 const { year, language } = Astro.props;
 
 function formatDate(date: string) {
-  return Intl.DateTimeFormat(language, {
-    month: "long",
-    day: "numeric",
-    year: "numeric",
-  }).format(new Date(date));
+  if (date) {
+    return Intl.DateTimeFormat(language, {
+      month: "long",
+      day: "numeric",
+      year: "numeric",
+    }).format(new Date(date));
+  } else {
+    return "TBD";
+  }
 }
 
 const program = await getProgram(year, language);


### PR DESCRIPTION
Makes it so we can setup next years program faster without worrying about what the date should be :sweat_smile:  

Like this:
![image](https://github.com/user-attachments/assets/4a857492-2a37-468e-bee0-687d01db0bc6)