### PR TITLE
Temporarily disable signup button with placeholder text

### DIFF
--- a/src/components/Main/Hero.astro
+++ b/src/components/Main/Hero.astro
@@ -48,12 +48,10 @@ const program = await getProgram(year, language);
     {t("main.description")}
   </p>
 
-  <a href="https://skjema.fribyte.no/index.php/455472" target="_blank">
-    <button>
-      {t("main.signUp")}
-      <img src="/arrow-up-right.svg" alt="arrow up right icon" />
-    </button>
-  </a>
+  <button disabled>
+    {t("main.signUp")}
+    <img src="/arrow-up-right.svg" alt="arrow up right icon" />
+  </button>
 </div>
 
 <style>
@@ -131,6 +129,11 @@ const program = await getProgram(year, language);
   button:hover {
     background-color: #3ff1ce;
     border-color: rgba(255, 255, 255, 0.2);
+  }
+  button:disabled {
+    cursor: default;
+    background-color: #12e8be;
+    border-color: rgba(0, 0, 0, 0.1);
   }
 
   @media only screen and (min-width: 768px) {

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -10,7 +10,7 @@ export const no = {
   "main.subTitle": "Bergen Open Source Konferanse",
   "main.description":
     "Bergen Open Source er en årlig teknologikonferanse i Bergen drevet av studenter og andre frivillige. Konferansen har fokus på fri åpen kildekode og åpne data.",
-  "main.signUp": "Meld deg på",
+  "main.signUp": "Påmelding kommer",
   "about.about":
     "  har som mål om å skape en møteplass for studenter og næringsliv i Bergen. Vi ønsker å skape en konferanse som er tilgjengelig for alle, og som kan være en arena for å lære bort og inspirere til åpen kildekode og åpne data.",
   "about.learnmore": "Mer om friByte",
@@ -51,7 +51,7 @@ export const en: typeof no = {
   "main.subTitle": "Bergen Open Source Conference",
   "main.description":
     "Bergen Open Source is a yearly tech-conference in Bergen by students and other volunteers. The key focus is free open source and open data.",
-  "main.signUp": "Sign up",
+  "main.signUp": "Registration opens soon",
   "about.about":
     " aims to create a meeting place for students and businesses in Bergen. We want to create a conference that is accessible to everyone and can serve as a platform for teaching and inspiring open source and open data.",
   "about.learnmore": "More about friByte",


### PR DESCRIPTION
Removed the link to the old sign-up form and disabled the sign-up button. Will change this back with a link to the sign up form as soon as it is ready.

<img width="309" height="96" alt="bilde" src="https://github.com/user-attachments/assets/9d56b408-4b2d-4b40-a45f-516ba01642a8" />


<img width="344" height="96" alt="bilde" src="https://github.com/user-attachments/assets/1cb21217-6323-4f8c-ba72-4d86dda1b8fc" />
