### PR TITLE
Add sponsor logo for Kantega and Tietoevry

### DIFF
--- a/src/program/2025.ts
+++ b/src/program/2025.ts
@@ -153,7 +153,16 @@ const program2025: Program = {
     },
   ],
   sponsors: [
-
+    {
+      "name": "Kantega",
+      "logo": "/sponsors/kantega.svg",
+      "url": "https://www.kantega.no/"
+    },
+    {
+      name: "TietoEvry",
+      logo: "/sponsors/tietoevry.svg",
+      url: "https://www.tietoevry.com/",
+    },
   ],
 };
 


### PR DESCRIPTION
<img width="1512" height="672" alt="bilde" src="https://github.com/user-attachments/assets/dba454d0-b5e2-4fbe-9847-3eb79fee545f" />
