### PR TITLE
Add code of conduct

### DIFF
--- a/src/components/Main/Header.astro
+++ b/src/components/Main/Header.astro
@@ -23,6 +23,9 @@ const t = useTranslation(Astro.url);
         <a href={url("/archive/")}>{t("header.archive")}</a>
       </li>
       <li>
+        <a href={url("/about/")}>{t("header.about")}</a>
+      </li>
+      <li>
         <LanguageSwitch />
       </li>
     </ul>

--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -6,6 +6,7 @@ export const languages = {
 export const no = {
   "header.home": "Hjem",
   "header.archive": "Arkiv",
+  "header.about": "Om oss",
   "main.title": "En dag fylt med åpen kildekode i Bergen!",
   "main.subTitle": "Bergen Open Source Konferanse",
   "main.description":
@@ -24,6 +25,11 @@ export const no = {
   "sponsors.apply": "Kontakt oss for å bli sponsor",
   "speakers.title": "Våre talere",
   "faq.title": "Spørsmål?",
+  "about.title": "Om Bergen Open Source",
+  "about.description": "Bergen Open Source er en årlig teknologikonferanse i Bergen drevet av studenter og andre frivillige. Konferansen har fokus på fri åpen kildekode og åpne data.",
+  "codeofconduct.title": "Etiske retningslinjer",
+  "codeofconduct.description": "Alle deltakere på Bergen Open Source-konferansen, samt bidragsytere til vår offentlige programvare, forplikter seg til å følge våre etiske retningslinjer.",
+  "codeofconduct.link": "Etiske retningslinjer for Bergen Open Source",
   "archive.title": "Arkiv fra tidligere BOS-konferanser",
   "archive.description": "Lyst til å se på tidligere konferanser? Ta en titt på en av våres tidligere år under.",
   "footer.sourceLink": "Kildekode",
@@ -48,6 +54,7 @@ export const no = {
 export const en: typeof no = {
   "header.home": "Home",
   "header.archive": "Archive",
+  "header.about": "About",
   "main.title": "A day filled with open source in Bergen!",
   "main.subTitle": "Bergen Open Source Conference",
   "main.description":
@@ -66,6 +73,11 @@ export const en: typeof no = {
   "sponsors.apply": "Contact us to become a sponsor",
   "speakers.title": "Our speakers",
   "faq.title": "Questions?",
+  "about.title": "About Bergen Open Source",
+  "about.description": "Bergen Open Source is a yearly tech-conference in Bergen by students and other volunteers. The key focus is free open source and open data.",
+  "codeofconduct.title": "Code of Conduct",
+  "codeofconduct.description": "All participants of the Bergen Open Source Conference, as well as contributors to our public software, agree to abide by our Code of Conduct.",
+  "codeofconduct.link": "Code of conduct for Bergen Open Source",
   "archive.title": "Archive of previous BOS-conferences",
   "archive.description": "Want to take a look at past conferences? Take a look at one of our previous years below.",
   "footer.sourceLink": "Source code",

--- a/src/layouts/About.astro
+++ b/src/layouts/About.astro
@@ -1,0 +1,29 @@
+---
+import { getLangFromUrl, useTranslation } from "../i18n/utils";
+import Layout from "./Layout.astro";
+
+const { frontmatter } = Astro.props;
+const lang = getLangFromUrl(Astro.url);
+const t = useTranslation(Astro.url);
+---
+
+<Layout>
+  <main>
+    <div class="markdown-text">
+      <slot />
+    </div>
+  </main>
+</Layout>
+
+<style>
+  main {
+    color: #fff;
+    max-width: var(--content-width);
+    margin: 0 auto;
+    padding: 1em;
+  }
+  .markdown-text {
+    max-width: var(--content-width);
+    margin-bottom: 3rem;
+  }
+</style>

--- a/src/pages/about/codeofconduct/index.md
+++ b/src/pages/about/codeofconduct/index.md
@@ -1,0 +1,21 @@
+---
+layout: "../../../layouts/About.astro"
+title: "Code of Conduct"
+description: "Code of Conduct for Bergen Open Source."
+---
+
+# Etiske Retningslinjer
+
+Alle deltakere, ansatte og frivillige på Bergen Open Source-konferansen, samt bidragsytere til våre åpne prosjekter på GitHub, skal følge disse retningslinjene.
+
+## Oppførsel under konferansen
+
+Vi ønsker at Bergen Open Source-konferansen skal være et hyggelig og inkluderende arrangement. Alle deltakere, foredragsholdere, ansatte og frivillige skal opptre med respekt overfor andre og vise vanlig høflighet.
+
+Trakassering av andre, diskriminerende handlinger eller oppførsel som forstyrrer konferansen vil føre til enten en advarsel eller utestengelse fra arrangementet, avhengig av alvorlighetsgrad. Styremedlemmene i Bergen Open Source har full myndighet til å fjerne enhver deltaker som, innen rimelighetens grenser, bryter disse retningslinjene.
+
+Dersom du opplever trakassering, uønsket oppmerksomhet eller annen ubehagelig oppførsel, ber vi deg kontakte en av arrangørene i Bergen Open Source.
+
+## Bidra til Bergen Open Source
+
+Vi setter pris på alle typer bidrag: kode, dokumentasjon, design og idéer. Vær respektfull og hjelpsom når du diskuterer eller foreslår endringer.

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,0 +1,57 @@
+---
+import Layout from "../../layouts/Layout.astro";
+import { useTranslation } from "../../i18n/utils";
+const t = useTranslation(Astro.url);
+---
+
+<Layout title="About">
+  <div class="container">
+    <div class="content">
+      <h1>{t("about.title")}</h1>
+      <div class="txtCont">
+        <p>
+          {t("about.description")}
+        </p>
+        <h2>{t("codeofconduct.title")}</h2>
+        <p>{t("codeofconduct.description")}</p>
+        <a href="codeofconduct">{t("codeofconduct.link")}</a>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .content {
+    color: #f1f1f1;
+    padding: 1rem 2rem;
+    max-width: var(--content-width);
+    margin: 0 auto;
+  }
+
+  .txtCont {
+    width: 100%;
+
+    p {
+      font-size: 1.2rem;
+      font-weight: 300;
+    }
+    a {
+      width: max-content;
+      margin: 6rem 0 0 0;
+      color: #12e8be;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    ul li {
+      margin-left: 2rem;
+      list-style-type: disc;
+    }
+  }
+
+  @media only screen and (min-width: 768px) {
+    .txtCont {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/pages/en/about/codeofconduct/index.md
+++ b/src/pages/en/about/codeofconduct/index.md
@@ -1,0 +1,21 @@
+---
+layout: "../../../../layouts/About.astro"
+title: "Code of Conduct"
+description: "Code of Conduct for Bergen Open Source."
+---
+
+# Code Of Conduct
+
+All attendees, staff and volunteers at the Bergen Open Source conference, as well as contributors to our open source software, are expected to follow this Code of Conduct.
+
+## At the conference
+
+We want the Bergen Open Source conference to be an enjoyable and welcoming event. All attendees, staff, speakers and volunteers are expected to behave respectfully towards others and show common courtesy.
+
+Harassment of others, discriminatory actions, or behaviour that disrupts the conference will result in either a warning or removal from the event, depending on the severity. The board members of Bergen Open Source have full authority to remove any attendee who, within reason, violates these rules.
+
+If you experience harassment, unwanted attention, or any other inappropriate behaviour, please contact one of the Bergen Open Source organizers.
+
+## Contributing to our software
+
+We welcome all kinds of contributions: code, documentation, design and ideas. Be respectful and helpful when discussing or suggesting changes.

--- a/src/pages/en/about/index.astro
+++ b/src/pages/en/about/index.astro
@@ -1,0 +1,57 @@
+---
+import Layout from "../../../layouts/Layout.astro";
+import { useTranslation } from "../../../i18n/utils";
+const t = useTranslation(Astro.url);
+---
+
+<Layout title="About">
+  <div class="container">
+    <div class="content">
+      <h1>{t("about.title")}</h1>
+      <div class="txtCont">
+        <p>
+          {t("about.description")}
+        </p>
+        <h2>{t("codeofconduct.title")}</h2>
+        <p>{t("codeofconduct.description")}</p>
+        <a href="codeofconduct">{t("codeofconduct.link")}</a>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .content {
+    color: #f1f1f1;
+    padding: 1rem 2rem;
+    max-width: var(--content-width);
+    margin: 0 auto;
+  }
+
+  .txtCont {
+    width: 100%;
+
+    p {
+      font-size: 1.2rem;
+      font-weight: 300;
+    }
+    a {
+      width: max-content;
+      margin: 6rem 0 0 0;
+      color: #12e8be;
+    }
+    a:hover {
+      text-decoration: underline;
+    }
+    ul li {
+      margin-left: 2rem;
+      list-style-type: disc;
+    }
+  }
+
+  @media only screen and (min-width: 768px) {
+    .txtCont {
+      width: 100%;
+    }
+  }
+</style>


### PR DESCRIPTION
Added a short Code of Conduct in both Norwegian and English, along with a new About page.

Related issue #53 

## About page
<img width="1108" height="562" alt="bilde" src="https://github.com/user-attachments/assets/cafaa8a9-1945-41eb-b05b-3ff42342d160" />

## Code of conduct
<img width="1114" height="608" alt="bilde" src="https://github.com/user-attachments/assets/a5993a83-bae5-4b14-83a0-ad54af414c24" />

