### PR TITLE
Fix issue 61 readability of speaker content

### DIFF
--- a/src/components/Main/Speakers.astro
+++ b/src/components/Main/Speakers.astro
@@ -76,7 +76,7 @@ const t = useTranslation(undefined, language);
     transition-duration: 0.25s;
     width: 300px;
     height: 400px;
-    background-color: #0C0A09;
+    background-color: #31313b;
     border-radius: 34px;
     overflow: hidden;
   }


### PR DESCRIPTION
Created an overlay with a transparent to black linear gradient for better readability of the speaker's name and description