### PR TITLE
Add table with names and positions of BOS board members

### DIFF
--- a/src/i18n/translations.ts
+++ b/src/i18n/translations.ts
@@ -80,6 +80,14 @@ export const no = {
   "support.contact": "Kontakt oss på",
   "donation-terms.title": "Avtalevilkår for donasjoner",
   "donation-terms.link": "Les avtalevilkårene",
+  "board.title": "Styremedlemmer",
+  "board.name": "Navn",
+  "board.position": "Stilling",
+  "board.leader": "Leder",
+  "board.deputyleader": "Nestleder",
+  "board.financialmanager": "Økonomiansvarlig",
+  "board.sponsorshipmanager": "Sponsoransvarlig",
+  "board.pr": "PR Ansvarlig",
 };
 export const en: typeof no = {
   "header.home": "Home",
@@ -159,4 +167,12 @@ export const en: typeof no = {
   "support.contact": "Contact us at",
   "donation-terms.title": "Terms and Conditions for donations",
   "donation-terms.link": "Read the terms and conditions",
+  "board.title": "Board Members",
+  "board.name": "Name",
+  "board.position": "Role",
+  "board.leader": "Leader",
+  "board.deputyleader": "Deputy Leader",
+  "board.financialmanager": "Financial Manager",
+  "board.sponsorshipmanager": "Sponsorship Manager",
+  "board.pr": "Head of PR",
 };

--- a/src/members.ts
+++ b/src/members.ts
@@ -1,0 +1,32 @@
+import { no } from "./i18n/translations";
+
+type TranslationKey = keyof typeof no;
+
+export type Member = {
+  name: string;
+  positionKey: TranslationKey;
+};
+
+export const members: Member[] = 
+[
+  {
+    "name": "Christian Engelsen",
+    "positionKey": "board.leader"
+  },
+  {
+    "name": "Johannes Lysne",
+    "positionKey": "board.deputyleader"
+  },
+  {
+    "name": "Johannes Skivdal",
+    "positionKey": "board.financialmanager"
+  },
+  {
+    "name": "Sindre Kjelsrud",
+    "positionKey": "board.sponsorshipmanager"
+  },
+  {
+    "name": "Ole Gåsvær",
+    "positionKey": "board.pr"
+  }
+]

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../layouts/Layout.astro";
 import { useTranslation } from "../../i18n/utils";
+import { members } from "../../members";
 const t = useTranslation(Astro.url);
 ---
 
@@ -16,6 +17,25 @@ const t = useTranslation(Astro.url);
         <p>{t("codeofconduct.description")}</p>
         <a href="codeofconduct">{t("codeofconduct.link")}</a>
       </div>
+      <h2>{t("board.title")}</h2>
+      <table class="members-table">
+        <thead>
+          <tr>
+            <th>{t("board.name")}</th>
+            <th>{t("board.position")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            members.map((member) => (
+              <tr>
+                <td>{member.name}</td>
+                <td>{t(member.positionKey)}</td>
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
     </div>
   </div>
 </Layout>
@@ -47,6 +67,23 @@ const t = useTranslation(Astro.url);
       margin-left: 2rem;
       list-style-type: disc;
     }
+  }
+
+  .members-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1.5rem;
+  }
+
+  .members-table th,
+  .members-table td {
+    text-align: left;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #ddd;
+  }
+
+  .members-table th {
+    font-weight: 600;
   }
 
   @media only screen and (min-width: 768px) {

--- a/src/pages/en/about/index.astro
+++ b/src/pages/en/about/index.astro
@@ -1,6 +1,7 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
 import { useTranslation } from "../../../i18n/utils";
+import { members } from "../../../members";
 const t = useTranslation(Astro.url);
 ---
 
@@ -16,6 +17,25 @@ const t = useTranslation(Astro.url);
         <p>{t("codeofconduct.description")}</p>
         <a href="codeofconduct">{t("codeofconduct.link")}</a>
       </div>
+      <h2>{t("board.title")}</h2>
+      <table class="members-table">
+        <thead>
+          <tr>
+            <th>{t("board.name")}</th>
+            <th>{t("board.position")}</th>
+          </tr>
+        </thead>
+        <tbody>
+          {
+            members.map((member) => (
+              <tr>
+                <td>{member.name}</td>
+                <td>{t(member.positionKey)}</td>
+              </tr>
+            ))
+          }
+        </tbody>
+      </table>
     </div>
   </div>
 </Layout>
@@ -47,6 +67,23 @@ const t = useTranslation(Astro.url);
       margin-left: 2rem;
       list-style-type: disc;
     }
+  }
+
+  .members-table {
+    width: 100%;
+    border-collapse: collapse;
+    margin-top: 1.5rem;
+  }
+
+  .members-table th,
+  .members-table td {
+    text-align: left;
+    padding: 0.75rem 0;
+    border-bottom: 1px solid #ddd;
+  }
+
+  .members-table th {
+    font-weight: 600;
   }
 
   @media only screen and (min-width: 768px) {


### PR DESCRIPTION
Added a board members table to the "about page" with Norwegian and English translations. Board member data is managed in members.ts, which is the only file that needs updating when the board changes. Additional fields like email can easily be added here if needed in the future.

Relates to #26. Do we need any additional information (images etc)?

<img width="976" height="555" alt="bilde" src="https://github.com/user-attachments/assets/c5d3a21c-1fae-4bbf-8521-bd15f301371d" />
