### PR TITLE
Fix: Add content for sponsor page in english

### DIFF
--- a/src/components/Main/About.astro
+++ b/src/components/Main/About.astro
@@ -1,19 +1,24 @@
 ---
-import { useTranslation } from "../../i18n/utils";
+import { useTranslation, getLocalizedUrl } from "../../i18n/utils";
 const t = useTranslation(Astro.url);
+const url = (path: string) => getLocalizedUrl(Astro.url, path);
 ---
 
 <div class="content">
   <div class="imgTxtCont">
     <div class="imgCont">
-      <img src="/mathias_present.webp" alt="One of last years speakers" loading="lazy" />
+      <img
+        src="/mathias_present.webp"
+        alt="One of last years speakers"
+        loading="lazy"
+      />
     </div>
     <div class="txtCont">
       <p>
         <span class="heroTxt">BOS konferansen</span>
         {t("about.about")}
       </p>
-<a href="/about" class="learn-more">{t("about.learnmore")}</a>
+      <a href={url("/about")} class="learn-more">{t("about.learnmore")}</a>
     </div>
   </div>
 </div>

--- a/src/components/Main/Header.astro
+++ b/src/components/Main/Header.astro
@@ -1,12 +1,13 @@
 ---
-import { getLangFromUrl, useTranslation } from "../../i18n/utils";
+import {
+  getLangFromUrl,
+  useTranslation,
+  getLocalizedUrl,
+} from "../../i18n/utils";
 import LanguageSwitch from "../LanguageSwitch.astro";
 
-import { getRelativeLocaleUrl } from "astro:i18n";
-function url(path: string) {
-  return getRelativeLocaleUrl(getLangFromUrl(Astro.url), path);
-}
 const t = useTranslation(Astro.url);
+const url = (path: string) => getLocalizedUrl(Astro.url, path);
 ---
 
 <header class="head">

--- a/src/components/Main/Sponsors.astro
+++ b/src/components/Main/Sponsors.astro
@@ -1,5 +1,5 @@
 ---
-import { useTranslation } from "../../i18n/utils";
+import { useTranslation, getLocalizedUrl } from "../../i18n/utils";
 import type { Sponsor } from "../../program/program";
 
 interface Props {
@@ -8,6 +8,7 @@ interface Props {
 const { sponsors } = Astro.props;
 
 const t = useTranslation(Astro.url);
+const url = (path: string) => getLocalizedUrl(Astro.url, path);
 ---
 
 <div class="cont">
@@ -16,18 +17,22 @@ const t = useTranslation(Astro.url);
     {
       sponsors.map((sponsor) =>
         sponsor.logo ? (
-          <a href={sponsor.url} target="_blank">
-            <img src={sponsor.logo} alt={sponsor.name + " logo"} loading="lazy" />
+          <a href={url(sponsor.url)} target="_blank">
+            <img
+              src={sponsor.logo}
+              alt={sponsor.name + " logo"}
+              loading="lazy"
+            />
           </a>
         ) : (
-          <a href={sponsor.url} class="placeholder-card">
+          <a href={url(sponsor.url)} class="placeholder-card">
             <span class="placeholder-text">{sponsor.name}</span>
           </a>
-        )
+        ),
       )
     }
   </div>
-  <a class="call-to-action" href="/sponsor">
+  <a class="call-to-action" href={url("/sponsor")}>
     {t("sponsors.apply")}
     <img src="/arrow-up-right.svg" alt="arrow up right" />
   </a>

--- a/src/i18n/utils.ts
+++ b/src/i18n/utils.ts
@@ -1,7 +1,18 @@
+import { getRelativeLocaleUrl } from "astro:i18n";
 import { en, no } from "./translations";
 
 export const langs = { no, en };
 const defaultLang = "no";
+
+/**
+ * Returns an internal URL for the current page language.
+ * @param currentUrl The current URL to get the language from
+ * @param path The path to the page, e.g. "/sponsors"
+ * @returns An internal URL for the current page language
+ */
+export function getLocalizedUrl(currentUrl: URL, path: string) {
+  return getRelativeLocaleUrl(getLangFromUrl(currentUrl), path);
+}
 
 /**
  * Get the language from the URL.

--- a/src/pages/en/sponsor.astro
+++ b/src/pages/en/sponsor.astro
@@ -1,5 +1,80 @@
 ---
-import GenericSponsor from "../sponsor.astro";
+import Layout from "../../layouts/Layout.astro";
+import { useTranslation } from "../../i18n/utils";
+const t = useTranslation(Astro.url);
+const goods = t<string[]>("sponsors.goods");
 ---
 
-<GenericSponsor />
+<Layout title="Bergen Open Source-konferanse">
+  <div class="container">
+    <div class="content">
+      <div class="imgTxtCont">
+        <h1>{t("sponsors.becomeTitle")}</h1>
+        <div class="txtCont">
+          <p>
+            {t("sponsors.become")}
+            <p>
+              {t("sponsors.contact1")}
+              {t("sponsors.contact2")}<a
+                href="mailto:sponsor@boskonf.no"
+                class="heroTxt">sponsor@boskonf.no</a
+              >
+            </p>
+            <p>{t("sponsors.price")}</p>
+            <div>
+              {
+                goods.map((item) => (
+                  <ul>
+                    <li>{item}</li>
+                  </ul>
+                ))
+              }
+            </div>
+          </p>
+        </div>
+      </div>
+    </div>
+  </div>
+</Layout>
+
+<style>
+  .content {
+    color: #f1f1f1;
+    padding: 1rem 2rem;
+    max-width: var(--content-width);
+    margin: 0 auto;
+  }
+
+  .txtCont {
+    width: 100%;
+
+    p {
+      font-size: 1.2rem;
+      font-weight: 300;
+    }
+    a {
+      width: max-content;
+      margin: 6rem 0 0 0;
+    }
+    ul li {
+      margin-left: 2rem;
+      list-style-type: disc;
+    }
+  }
+  .txtCont .heroTxt {
+    color: #12e8be;
+    font-weight: 500;
+  }
+
+  @media only screen and (min-width: 768px) {
+    .imgTxtCont {
+      flex-direction: row;
+    }
+    .imgCont {
+      width: 50%;
+    }
+    .txtCont {
+      width: 100%;
+    }
+  }
+</style>

--- a/src/pages/en/support/index.astro
+++ b/src/pages/en/support/index.astro
@@ -1,7 +1,8 @@
 ---
 import Layout from "../../../layouts/Layout.astro";
-import { useTranslation } from "../../../i18n/utils";
+import { useTranslation, getLocalizedUrl } from "../../../i18n/utils";
 const t = useTranslation(Astro.url);
+const url = (path: string) => getLocalizedUrl(Astro.url, path);
 ---
 
 <Layout title="Support">
@@ -13,7 +14,7 @@ const t = useTranslation(Astro.url);
           {t("support.description")}
         </p>
         <h2>{t("support.ways")}</h2>
-        
+
         <h3>{t("support.donate.title")}</h3>
         <p>{t("support.donate.description")}</p>
         <ul>
@@ -25,7 +26,12 @@ const t = useTranslation(Astro.url);
           <li>
             <h4>{t("support.donate.bank.title")}</h4>
             <p>{t("support.donate.bank.description")}</p>
-            <p>{t("support.donate.bank.label")} <span class="account-number">{t("support.donate.bank.number")}</span></p>
+            <p>
+              {t("support.donate.bank.label")}
+              <span class="account-number"
+                >{t("support.donate.bank.number")}</span
+              >
+            </p>
             <p>{t("support.donate.bank.info")}</p>
           </li>
         </ul>
@@ -35,7 +41,7 @@ const t = useTranslation(Astro.url);
 
         <h3>{t("support.sponsor.title")}</h3>
         <p>{t("support.sponsor.description")}</p>
-        <a href="/sponsor">{t("support.sponsor.link")}</a>
+        <a href={url("/sponsor")}>{t("support.sponsor.link")}</a>
 
         <h3>{t("support.spread.title")}</h3>
         <p>{t("support.spread.description")}</p>

--- a/src/pages/en/support/index.astro
+++ b/src/pages/en/support/index.astro
@@ -46,7 +46,7 @@ const url = (path: string) => getLocalizedUrl(Astro.url, path);
         <h3>{t("support.spread.title")}</h3>
         <p>{t("support.spread.description")}</p>
 
-        <p>{t("support.contact")} 📨: boss@fribyte.no</p>
+        <p>{t("support.contact")} 📨: post(at)boskonf.no</p>
       </div>
     </div>
   </div>

--- a/src/pages/support/index.astro
+++ b/src/pages/support/index.astro
@@ -1,7 +1,8 @@
 ---
 import Layout from "../../layouts/Layout.astro";
-import { useTranslation } from "../../i18n/utils";
+import { useTranslation, getLocalizedUrl } from "../../i18n/utils";
 const t = useTranslation(Astro.url);
+const url = (path: string) => getLocalizedUrl(Astro.url, path);
 ---
 
 <Layout title="Support">
@@ -13,7 +14,7 @@ const t = useTranslation(Astro.url);
           {t("support.description")}
         </p>
         <h2>{t("support.ways")}</h2>
-        
+
         <h3>{t("support.donate.title")}</h3>
         <p>{t("support.donate.description")}</p>
         <ul>
@@ -25,7 +26,12 @@ const t = useTranslation(Astro.url);
           <li>
             <h4>{t("support.donate.bank.title")}</h4>
             <p>{t("support.donate.bank.description")}</p>
-            <p>{t("support.donate.bank.label")} <span class="account-number">{t("support.donate.bank.number")}</span></p>
+            <p>
+              {t("support.donate.bank.label")}
+              <span class="account-number"
+                >{t("support.donate.bank.number")}</span
+              >
+            </p>
             <p>{t("support.donate.bank.info")}</p>
           </li>
         </ul>
@@ -35,7 +41,7 @@ const t = useTranslation(Astro.url);
 
         <h3>{t("support.sponsor.title")}</h3>
         <p>{t("support.sponsor.description")}</p>
-        <a href="/sponsor">{t("support.sponsor.link")}</a>
+        <a href={url("/sponsor")}>{t("support.sponsor.link")}</a>
 
         <h3>{t("support.spread.title")}</h3>
         <p>{t("support.spread.description")}</p>


### PR DESCRIPTION
Add content to the /en/sponsor/ page that was missing.