### PR TITLE
fix: Fix accessibility issues

### DIFF
--- a/public/footer/earth.svg
+++ b/public/footer/earth.svg
@@ -2,7 +2,7 @@
 
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
-<svg  version="1.1" id="_x32_" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
+<svg  version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" 
 	 viewBox="0 0 512 512"  xml:space="preserve">
 <style type="text/css">
 	.st0{fill:currentColor;}

--- a/src/components/FancyExternalLink.astro
+++ b/src/components/FancyExternalLink.astro
@@ -4,12 +4,9 @@ import arrow from "../../public/arrow-up-right.svg?raw";
 interface Props {
   url: string;
   text: string;
-  light?: boolean;
 }
 
-const { url, text, light = true } = Astro.props;
-
-const color = light ? "rgb(173, 241, 255) " : "rgb(33, 82, 187)";
+const { url, text} = Astro.props;
 ---
 
 <a href={url} target="_blank">
@@ -17,7 +14,7 @@ const color = light ? "rgb(173, 241, 255) " : "rgb(33, 82, 187)";
   <Fragment set:html={arrow} />
 </a>
 
-<style define:vars={{ "link-color": color }}>
+<style define:vars={{ "link-color": "#12e8be" }}>
   a {
     display: flex;
     align-items: center;

--- a/src/components/Main/Schedule/ScheduleStack.astro
+++ b/src/components/Main/Schedule/ScheduleStack.astro
@@ -63,7 +63,6 @@ function formatDuration(from: string, to: string) {
               <FancyExternalLink
                 text={attach.name}
                 url={attach.url}
-                light={false}
               />
             </li>
           ))

--- a/src/layouts/About.astro
+++ b/src/layouts/About.astro
@@ -7,7 +7,7 @@ const lang = getLangFromUrl(Astro.url);
 const t = useTranslation(Astro.url);
 ---
 
-<Layout>
+<Layout title={frontmatter.title}>
   <main>
     <div class="markdown-text">
       <slot />

--- a/src/pages/about/index.astro
+++ b/src/pages/about/index.astro
@@ -5,7 +5,7 @@ import { members } from "../../members";
 const t = useTranslation(Astro.url);
 ---
 
-<Layout title="About">
+<Layout title={t("about.title")}>
   <div class="container">
     <div class="content">
       <h1>{t("about.title")}</h1>

--- a/src/pages/en/about/index.astro
+++ b/src/pages/en/about/index.astro
@@ -5,7 +5,7 @@ import { members } from "../../../members";
 const t = useTranslation(Astro.url);
 ---
 
-<Layout title="About">
+<Layout title={t("about.title")}>
   <div class="container">
     <div class="content">
       <h1>{t("about.title")}</h1>

--- a/src/pages/support/donation-terms/index.md
+++ b/src/pages/support/donation-terms/index.md
@@ -1,7 +1,7 @@
 ---
 layout: "../../../layouts/About.astro"
-title: "Terms and Conditions"
-description: "Terms and Conditions for donations to Bergen Open Source."
+title: "Avtalevilkår for donasjoner"
+description: "Avtalevilkår for donasjoner til Bergen Open Source."
 ---
 
 # Avtalevilkår for donasjoner
@@ -20,4 +20,4 @@ Det er ingen bindingstid, så du kan når som helst si opp eller endre avtalen g
 
 ## Personopplysninger
 
-Vi behandler nødvendige opplysninger som navn, telefonnummer og betalingsdetaljer kun for å administrere donasjonen, i samsvar med GDPR. Vi kommer ikke til å bruke dataen til noen andre formål enn å kunne verifisere hvem som har donert hva når eventuelle feil skjer i betalingskjeden eller ved kansellering av faste donasjoner. Data deles ikke med tredjeparter utover Vipps. Kontakt oss på post(at)boskonf.no om du har spørsmål. 
+Vi behandler nødvendige opplysninger som navn, telefonnummer og betalingsdetaljer kun for å administrere donasjonen, i samsvar med GDPR. Vi kommer ikke til å bruke dataen til noen andre formål enn å kunne verifisere hvem som har donert hva når eventuelle feil skjer i betalingskjeden eller ved kansellering av faste donasjoner. Data deles ikke med tredjeparter utover Vipps. Kontakt oss på post(at)boskonf.no om du har spørsmål.


### PR DESCRIPTION
> _Closes #116_

To do an automated check for this PR, try using `npx pa11y-ci --sitemap http://localhost:4321/sitemap-0.xml` after running `npm run build && npm run preview`.

## Fixes

- No more duplicate ids for an svg
- Fix empty title-tag for About-layout
- Use translation title for About-layout
- Use norwegian title and description for donation-terms page instead of english
- Fix color contrast for presentation links